### PR TITLE
- feat: run offline without downtime(patch in v4.0.0)

### DIFF
--- a/lib/sequent/migrations/executor.rb
+++ b/lib/sequent/migrations/executor.rb
@@ -38,9 +38,9 @@ module Sequent
           table = migration.record_class
           current_table_name = table.table_name.gsub("_#{migration.version}", "")
           # 2 Rename old table
-          exec_sql("ALTER TABLE IF EXISTS #{current_table_name} RENAME TO #{current_table_name}_#{current_version}")
+          exec_sql("ALTER TABLE IF EXISTS view_schema.#{current_table_name} RENAME TO #{current_table_name}_#{current_version}")
           # 3 Rename new table
-          exec_sql("ALTER TABLE #{table.table_name} RENAME TO #{current_table_name}")
+          exec_sql("ALTER TABLE view_schema.#{table.table_name} RENAME TO #{current_table_name}")
           # Use new table from now on
           table.table_name = current_table_name
           table.reset_column_information


### PR DESCRIPTION
## How to test:
1. add `binding.pry` before `lib/sequent/migrations/view_schema.rb:206` 
2. add `binding.pry`  at `lib/sequent/migrations/view_schema.rb:207`
3. add `binding.pry` before `lib/sequent/migrations/view_schema.rb:218`
4. add new projector migration in gogovan-server `sequent_db/sequent_migrations.rb`
```ruby
'15' => [
  PrepaidWalletProjector
]
```
5. In gogovan-server run `rake sequent:migrate:online` 
6. In gogovan-server run `rake sequent:migrate:offline` 
7. when run to `binding.pry`
In gogovan-server rails console topup $100
```ruby
topup_transaction_reference_uuid = Sequent.new_uuid
aggregate_id = 'f98b6660-38b9-43d0-b903-d9e534cf7d19'
topup_package = PrepaidWalletTopupPackage.find(25)
payment_method = :alipay
topped_up_at = DateTime.current
admin_user_id = nil
remarks = nil
payment_method_credit_card_metadata = nil

command = TopupPrepaidWallet.new(
  aggregate_id: aggregate_id,
  topup_transaction_reference_uuid: topup_transaction_reference_uuid,
  topup_package_id: topup_package.id,
  topup_package_title: topup_package.title,
  topup_package_description: topup_package.description,
  credits: topup_package.credits,
  first_time_free_credits: topup_package.first_time_free_credits,
  subsequent_free_credits: topup_package.subsequent_free_credits,
  free_credits_valid_days: topup_package.free_credits_valid_days,
  payment_method: payment_method,
  payment_method_credit_card_metadata: payment_method_credit_card_metadata,
  admin_user_id: admin_user_id,
  remarks: remarks,
  toped_up_at: topped_up_at
)

Sequent.command_service.execute_commands *command
```

8.  check the wallet(`aggregate_id = 'f98b6660-38b9-43d0-b903-d9e534cf7d19'`) add $300 to balance